### PR TITLE
ci(release): skip duplicate asset upload in publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,8 @@ jobs:
           ./gradlew patchChangelog
 
       # Publish the plugin to JetBrains Marketplace
+      # The release zip is already attached to the GitHub release by the
+      # Prepare Release workflow (the artifact PMC voted on); no upload here.
       - name: Publish Plugin
         env:
           PUBLISH_TOKEN: ${{ secrets.PUBLISH_TOKEN }}
@@ -86,12 +88,6 @@ jobs:
           PRIVATE_KEY: ${{ secrets.PRIVATE_KEY }}
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: ./gradlew publishPlugin
-
-      # Upload artifact as a release asset
-      - name: Upload Release Asset
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
       # Create a pull request with changelog update
       - name: Create Pull Request


### PR DESCRIPTION
## Summary

The two-phase release setup attached the plugin zip to the GitHub
pre-release in `prepare_release.yml`, then `release.yml` tried to
upload the same file again on promotion — failing the `v261.19017.1`
publish run with `asset under the same name already exists:
[struts2-261.19017.1.zip]`.

This removes the redundant `Upload Release Asset` step. The Marketplace
publish (the only step that needs to happen on promotion) already runs
before it, and the asset PMC voted on stays untouched.

See failing run: https://github.com/apache/struts-intellij-plugin/actions/runs/25051059276/job/73378668748

## Test plan

- [x] Next prepare → promote cycle completes without the upload error
- [x] Changelog-update PR is created on promotion (was skipped this time due to the upload failure)