### PR TITLE
Changelog update - `261.19017.1`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ## [Unreleased]
 
+## [261.19017.1] - 2026-04-28
+
 ### Added
 
 - Add read-only Diagram tab for struts.xml files with lightweight config visualization (packages, actions, results)
@@ -26,7 +28,6 @@
 - Replace deprecated `ReadAction.compute(ThrowableComputable)` with `ReadAction.nonBlocking().executeSynchronously()` (4 call sites)
 - Replace deprecated `DaemonCodeAnalyzer.restart(PsiFile)` with `restart(PsiFile, reason)` overload
 - Remove deprecated `CompletionType.CLASS_NAME` registration (covered by `CompletionType.BASIC`)
-
 - Fix private and deprecated API usages for JetBrains Marketplace approval:
   - Replace `IconManager.loadRasterizedIcon()` with `IconLoader.getIcon()` in icon classes
   - Replace `WebFacet.getWebRoots(boolean)` with `getWebRoots()` (parameter scheduled for removal)
@@ -89,9 +90,6 @@
 
 ### Temporarily Disabled Tests
 
-The following tests are temporarily disabled due to test infrastructure changes in IntelliJ Platform 2025.3.
-These tests need investigation and fixes for test data path resolution, highlighting comparison, and API behavior changes:
-
 - `OgnlLexerTest` - 4 tests (test data path resolution)
 - `StrutsCompletionTest.testCompletionVariantsPackageExtends` - FreezableArrayList issue
 - `StrutsHighlightingSpringTest` - 5 tests (Spring integration)
@@ -117,6 +115,7 @@ These tests need investigation and fixes for test data path resolution, highligh
 - Dependencies - upgrade `org.jetbrains.kotlinx.kover` to `0.8.3`
 - Dependencies - upgrade `org.jetbrains.qodana` to `2024.1.9`
 
-[Unreleased]: https://github.com/apache/struts-intellij-plugin/compare/v252.18978.1...HEAD
-[252.18978.1]: https://github.com/apache/struts-intellij-plugin/compare/v2.0.1...v252.18978.1
-[2.0.1]: https://github.com/apache/struts-intellij-plugin/releases/tag/v2.0.1
+[Unreleased]: https://github.com/apache/struts-intellij-plugin//compare/v261.19017.1...HEAD
+[261.19017.1]: https://github.com/apache/struts-intellij-plugin//compare/v252.18978.1...v261.19017.1
+[252.18978.1]: https://github.com/apache/struts-intellij-plugin//compare/v2.0.1...v252.18978.1
+[2.0.1]: https://github.com/apache/struts-intellij-plugin//commits/v2.0.1


### PR DESCRIPTION
Current pull request contains patched `CHANGELOG.md` file for the `261.19017.1` version.

This PR was created manually because the automated step in `release.yml` was skipped after the `Upload Release Asset` step failed (see #80 for the workflow fix).

## Changes included in this release

### Added

- Add read-only Diagram tab for struts.xml files with lightweight config visualization (packages, actions, results)

### Changed

- Disable the deprecated Graph editor tab by default; opt in with JVM property `-Dcom.intellij.struts2.enableGraphEditor=true`
- Update `platformVersion` to `2026.1`
- Change since/until build to `261-261.*` (2026.1 only)
- Dependencies - upgrade `org.jetbrains.intellij.platform` to `2.13.1`
- Dependencies - upgrade Gradle to `9.0.0` (required by IntelliJ Platform Gradle Plugin 2.13.1)
- Convert pre-release publishing from per-push to nightly schedule
- Add two-phase release workflow with prepare and publish steps
- Merge PR artifact comment into build workflow
- Enable automerge of PRs
- Clean up README by removing template boilerplate

### Fixed

- Replace deprecated `ReadAction.compute(ThrowableComputable)` with `ReadAction.nonBlocking().executeSynchronously()` (4 call sites)
- Replace deprecated `DaemonCodeAnalyzer.restart(PsiFile)` with `restart(PsiFile, reason)` overload
- Remove deprecated `CompletionType.CLASS_NAME` registration (covered by `CompletionType.BASIC`)
- Fix private and deprecated API usages for JetBrains Marketplace approval:
  - Replace `IconManager.loadRasterizedIcon()` with `IconLoader.getIcon()` in icon classes
  - Replace `WebFacet.getWebRoots(boolean)` with `getWebRoots()` (parameter scheduled for removal)
  - Replace `AnActionButton` with `DumbAwareAction` in toolbar decorator
  - Replace `IdeFocusManager.doWhenFocusSettlesDown()` with direct `requestFocus()`
  - Replace `ResourceRegistrar.addStdResource(Class)` with ClassLoader-based version
  - Replace `FilenameIndex.getFilesByName()` with `getVirtualFilesByName()`
  - Replace deprecated `URL(String)` constructor with `URI.create().toURL()`
- Resolve deprecated API warnings from Marketplace verification:
  - Migrate `DaemonCodeAnalyzer.restart()` to `restart(PsiFile)` overload
  - Suppress unavoidable deprecations with no public replacements (`GraphBuilder`, `CheckboxTreeBase`)
  - Migrate `FacetConfiguration.readExternal()`/`writeExternal()` to `PersistentStateComponent<Element>`
- Strip leading slash from DTD resource path for IntelliJ 2025.3 `PluginClassLoader.findResource()` compatibility
- Resolve 21 critical nullability/NPE warnings from Qodana analysis across 15 files
- Resolve 22 Qodana warnings: redundant code, incorrect string capitalization, unnecessary null checks
- Migrate `Struts2GraphComponent` from `DataProvider` to `UiDataProvider`
- Exclude `src/main/gen` from Qodana scanning to suppress generated code warnings
- Fix nightly CI version collision: read branch prefix from `pluginVersion` and increment nightly counter from latest pre-release tag
- Fix nightly CI workflow to only target nightly pre-releases, avoiding interference with release candidates
- Fix nightly CI to exclude pre-releases when resolving latest build number

[261.19017.1]: https://github.com/apache/struts-intellij-plugin//compare/v252.18978.1...v261.19017.1