### PR TITLE
Bump pluginVersion to `261.19027.1`

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ pluginGroup = com.intellij.struts2
 pluginName = struts2
 pluginRepositoryUrl = https://github.com/apache/struts-intellij-plugin/
 # SemVer format -> https://semver.org
-pluginVersion = 261.19017.1
+pluginVersion = 261.19027.1
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 261


### PR DESCRIPTION
## Summary

Manually apply the post-release version-bump rule (introduced in #82) for the already-published `v261.19017.1`, which predates that automation.

- Previous release: `v252.18980.1`
- Current release: `v261.19017.1`
- Nightly tags between them: **10**
- New `pluginVersion`: `261.19027.1` (BUILD `19017` → `19027`)

The `BRANCH` (`261`) and `FIX` (`1`) segments are unchanged.

## Test plan

- [x] Next `Prepare Release` run picks up `261.19027.1` from `gradle.properties`