### PR TITLE
ci: pin Marketplace ZIP Signer to 0.1.43

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- Pin Marketplace ZIP Signer to `0.1.43` so `signPlugin` is deterministically resolvable and no longer fails with "No Marketplace ZIP Signer executable found" on a stale Gradle cache in the nightly/release workflows
+
 ## [261.19017.1] - 2026-04-28
 
 ### Added

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -65,7 +65,12 @@ dependencies {
         bundledPlugin("com.intellij.modules.json")
 
         pluginVerifier()
-        zipSigner()
+        // Pin the Marketplace ZIP Signer version so the signing dependency is always
+        // deterministically resolvable. Without a version, a stale Gradle cache restored
+        // by gradle/actions (e.g. saved by a non-signing build.yml run) can leave the
+        // signing configuration empty, causing signPlugin to fail with
+        // "No Marketplace ZIP Signer executable found" in the nightly/release workflows.
+        zipSigner("0.1.43")
 
         testFramework(TestFrameworkType.Platform)
         testFramework(TestFrameworkType.Plugin.Java)


### PR DESCRIPTION
## Problem

The **Nightly release** job (and by extension the release workflow) intermittently fails at `:signPlugin`:

```
Execution failed for task ':signPlugin'.
> No Marketplace ZIP Signer executable found.
  Please ensure the `zipSigner()` entry is present in the project dependencies section
  or `intellijPlatform.signing.cliPath` extension property
```

This is misleading — `zipSigner()` **is** already declared and `defaultRepositories()` is configured. The build config is unchanged since the last successful publish (`v261.19027-nightly.3`, 2026-05-20).

## Root cause

`zipSigner()` was declared without a version, so the signer is resolved as "latest". The `gradle/actions/setup-gradle` cache is restored from prior runs — including non-signing `build.yml` runs that never download `marketplace-zip-signer`. When the nightly restores such a cache, Gradle ends up with stale metadata and an empty signing configuration, producing the "no executable found" error. Re-running the job (which re-resolves) works around it, but the flake recurs.

Verified locally: the exact same config + `marketplace-zip-signer:0.1.43` resolves and runs fine even on a cold, `--refresh-dependencies` download — confirming the failure is environment/cache-specific, not a config bug.

## Fix

Pin the signer version so the dependency is always deterministically resolvable:

```kotlin
zipSigner("0.1.43")
```

`0.1.43` is the version that "latest" currently resolves to, so this is behavior-preserving while removing the cache-dependent flake.

## Testing

- `signPlugin` with the pinned version resolves and runs the signer (fails only on an intentionally-invalid test cert, not "no executable found").
- CHANGELOG updated under `Unreleased`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)