### PR TITLE
ci: require Struts version review before preparing release

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -27,6 +27,11 @@ on:
         description: 'Release version (e.g. 253.18970.1). Leave empty to use pluginVersion from gradle.properties.'
         required: false
         default: ''
+      struts_version_checked:
+        description: 'Confirm that support for the latest Apache Struts release has been reviewed.'
+        required: true
+        type: boolean
+        default: false
 
 jobs:
   prepare:
@@ -35,6 +40,13 @@ jobs:
     permissions:
       contents: write
     steps:
+
+      - name: Check release readiness
+        if: ${{ github.event.inputs.struts_version_checked != 'true' }}
+        run: |
+          echo "::error title=Release checklist incomplete::Review support for the latest Apache Struts release before preparing this plugin release."
+          echo "Check https://struts.apache.org/announce.html and update code, tests, and CHANGELOG.md if needed."
+          exit 1
 
       # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Nightly tags are also used when calculating the BUILD increment after a stable r
 
 #### Phase 1 — Prepare a release candidate (manual)
 
-Go to **Actions → Prepare Release → Run workflow** ([prepare_release.yml](.github/workflows/prepare_release.yml)), optionally providing a version override. If omitted, the version from `gradle.properties` is used. This workflow:
+Go to **Actions → Prepare Release → Run workflow** ([prepare_release.yml](.github/workflows/prepare_release.yml)), optionally providing a version override. If omitted, the version from `gradle.properties` is used. You must check **Confirm that support for the latest Apache Struts release has been reviewed** before the workflow runs. This workflow:
 
 1. Builds the plugin (`./gradlew buildPlugin`)
 2. Extracts unreleased changelog entries for the release notes
@@ -108,10 +108,11 @@ Merge the post-release PR to complete the release cycle.
 
 #### Pre-release checklist
 
-1. Ensure `[Unreleased]` in `CHANGELOG.md` is complete
-2. Confirm `pluginVersion` and platform properties in `gradle.properties` are correct
-3. Ensure `main` is green (required checks: Test, Verify plugin)
-4. Run **Prepare Release**
-5. Share the GitHub pre-release with PMC for testing and voting
-6. After the vote: promote pre-release → full release
-7. Review and merge the auto-created post-release PR
+1. Check the [latest Apache Struts release](https://struts.apache.org/announce.html) and update plugin support, tests, and `CHANGELOG.md` if needed
+2. Ensure `[Unreleased]` in `CHANGELOG.md` is complete
+3. Confirm `pluginVersion` and platform properties in `gradle.properties` are correct
+4. Ensure `main` is green (required checks: Test, Verify plugin)
+5. Run **Prepare Release** (check the Struts version confirmation box)
+6. Share the GitHub pre-release with PMC for testing and voting
+7. After the vote: promote pre-release → full release
+8. Review and merge the auto-created post-release PR


### PR DESCRIPTION
## Summary

- Add a required **Confirm that support for the latest Apache Struts release has been reviewed** checkbox to the Prepare Release workflow
- Fail early with a clear job error when the checkbox is not checked, pointing to https://struts.apache.org/announce.html
- Update the README pre-release checklist and Phase 1 instructions

## Test plan

- [ ] Open **Actions → Prepare Release** and confirm the new checkbox appears
- [ ] Run the workflow without checking the box and confirm it fails immediately with the release checklist error
- [ ] Run the workflow with the box checked and confirm the release candidate flow still works

Made with [Cursor](https://cursor.com)