### PR TITLE
build: declare JavaScript/JSP/CSS v2 content modules for 2026.2 (#103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Dependencies - upgrade `org.jetbrains.intellij.platform` to `2.18.1`
 - Dependencies - upgrade `org.jetbrains.kotlin.jvm` to `2.3.0`
 - Dependencies - upgrade Qodana linter image to `jetbrains/qodana-jvm:2026.2-eap`
+- Dependencies - declare IntelliJ Platform 2026.2 v2 content modules `intellij.javascript.parser`, `intellij.javascript.backend`, `intellij.javaee.jsp.shared`, `intellij.css`, and `intellij.css.backend` ([#103](https://github.com/apache/struts-intellij-plugin/issues/103))
 
 ## [261.19027.1] - 2026-07-13
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,8 @@ dependencies {
         bundledPlugin("com.intellij.velocity")
         bundledPlugin("org.intellij.groovy")
         bundledPlugin("JavaScript")
+        bundledModule("intellij.javascript.parser")
+        bundledModule("intellij.javascript.backend")
         bundledPlugin("com.intellij.css")
         bundledPlugin("intellij.structureView.plugin")
         bundledPlugin("com.intellij.modules.json")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -66,6 +66,8 @@ dependencies {
         bundledModule("intellij.javascript.parser")
         bundledModule("intellij.javascript.backend")
         bundledPlugin("com.intellij.css")
+        bundledModule("intellij.css")
+        bundledModule("intellij.css.backend")
         bundledPlugin("intellij.structureView.plugin")
         bundledPlugin("com.intellij.modules.json")
         bundledModule("intellij.xml.structureView")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,6 +56,7 @@ dependencies {
         bundledPlugin("com.intellij.javaee")
         bundledPlugin("com.intellij.javaee.web")
         bundledPlugin("com.intellij.jsp")
+        bundledModule("intellij.javaee.jsp.shared")
         bundledPlugin("com.intellij.spring")
         bundledPlugin("com.intellij.java-i18n")
         bundledPlugin("com.intellij.freemarker")

--- a/docs/superpowers/plans/2026-07-25-javascript-v2-modules.md
+++ b/docs/superpowers/plans/2026-07-25-javascript-v2-modules.md
@@ -1,0 +1,313 @@
+# JavaScript v2 Content Modules Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Declare IntelliJ Platform 2026.2 JavaScript v2 content modules so Struts JSP/FreeMarker JS injectors load without classloader errors.
+
+**Architecture:** Minimal declarative fix on top of the existing `JavaScript` plugin dependency. Add `intellij.javascript.parser` and `intellij.javascript.backend` in `plugin.xml` and matching `bundledModule(...)` entries in Gradle. Escalate to `intellij.javascript.common` (then broader modules) only if build, plugin verifier, or `runIde` shows a real classloader gap. No injector logic changes.
+
+**Tech Stack:** IntelliJ Platform Gradle Plugin 2.x, IntelliJ IDEA 2026.2 (`262.*`), Java 25, JetBrains Plugin Verifier.
+
+**Spec:** `docs/superpowers/specs/2026-07-25-javascript-v2-modules-design.md`  
+**Issue:** [#103](https://github.com/apache/struts-intellij-plugin/issues/103)
+
+## Global Constraints
+
+- Keep `<plugin id="JavaScript"/>` and `bundledPlugin("JavaScript")` — v2 `<module>` entries are **additional**.
+- Start with exactly `intellij.javascript.parser` and `intellij.javascript.backend`.
+- Add `intellij.javascript.common` only after a real `NoClassDefFoundError` / `ClassNotFoundException` for `com.intellij.lang.javascript.*`.
+- Broader modules (`psi.impl`, `analysis.impl`) only after `common` still fails.
+- Do **not** change `TaglibJavaScriptInjector` or `FreeMarkerJavaScriptInjector`.
+- Do **not** make JavaScript optional.
+- Do **not** add new automated JS injector tests.
+- Do **not** run prepare/publish release workflows.
+- Platform target is already 2026.2 / Java 25 (from #115); do not re-bump platform versions unless verification forces it.
+- Prefer public APIs; fix Marketplace-blocking verifier issues before merging.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/main/resources/META-INF/plugin.xml` | Modify | Declare JS v2 content modules next to existing `JavaScript` plugin dependency |
+| `build.gradle.kts` | Modify | Declare matching `bundledModule(...)` entries for compile/runtime classpath |
+| `CHANGELOG.md` | Modify | Record JavaScript v2 content module dependencies under Unreleased |
+| `docs/superpowers/specs/2026-07-25-javascript-v2-modules-design.md` | Reference only | Approved design decisions |
+| Injector sources under `src/main/java/.../jsp/` and `.../freemarker/` | Do not modify | Already use the classes hosted by the modules above |
+
+No new modules, extension points, or feature code.
+
+---
+
+### Task 1: Declare JavaScript v2 content modules
+
+**Files:**
+- Modify: `src/main/resources/META-INF/plugin.xml` (around the `<dependencies>` block containing `JavaScript`)
+- Modify: `build.gradle.kts` (around `bundledPlugin("JavaScript")`)
+
+**Interfaces:**
+- Consumes: existing required dependency on plugin id `JavaScript`
+- Produces: runtime/classpath access to `JavaScriptSupportLoader` (`intellij.javascript.parser`) and `JSInXmlLanguagesInjector` (`intellij.javascript.backend`)
+
+- [ ] **Step 1: Confirm current dependency wiring**
+
+Run:
+
+```bash
+rg -n 'JavaScript|javascript\.(parser|backend|common)|bundledModule' \
+  src/main/resources/META-INF/plugin.xml build.gradle.kts
+```
+
+Expected: `plugin.xml` has `<plugin id="JavaScript"/>` and no JS module entries yet; `build.gradle.kts` has `bundledPlugin("JavaScript")` and existing `bundledModule("intellij.xml.structureView*")` only.
+
+- [ ] **Step 2: Add modules to `plugin.xml`**
+
+In `src/main/resources/META-INF/plugin.xml`, change the JavaScript dependency lines from:
+
+```xml
+        <plugin id="JavaScript"/>
+        <plugin id="com.intellij.css"/>
+```
+
+to:
+
+```xml
+        <plugin id="JavaScript"/>
+        <module name="intellij.javascript.parser"/>
+        <module name="intellij.javascript.backend"/>
+        <plugin id="com.intellij.css"/>
+```
+
+Keep every other dependency unchanged.
+
+- [ ] **Step 3: Add matching Gradle `bundledModule` entries**
+
+In `build.gradle.kts`, inside `intellijPlatform { ... }`, change:
+
+```kotlin
+        bundledPlugin("JavaScript")
+        bundledPlugin("com.intellij.css")
+        bundledPlugin("intellij.structureView.plugin")
+        bundledPlugin("com.intellij.modules.json")
+        bundledModule("intellij.xml.structureView")
+        bundledModule("intellij.xml.structureView.impl")
+```
+
+to:
+
+```kotlin
+        bundledPlugin("JavaScript")
+        bundledModule("intellij.javascript.parser")
+        bundledModule("intellij.javascript.backend")
+        bundledPlugin("com.intellij.css")
+        bundledPlugin("intellij.structureView.plugin")
+        bundledPlugin("com.intellij.modules.json")
+        bundledModule("intellij.xml.structureView")
+        bundledModule("intellij.xml.structureView.impl")
+```
+
+- [ ] **Step 4: Resolve and compile to confirm modules exist on 2026.2**
+
+Run:
+
+```bash
+./gradlew compileJava --no-daemon
+```
+
+Expected: BUILD SUCCESSFUL. If Gradle fails with an unknown/`bundledModule` resolution error for either JS module name, stop and re-check JetBrains docs / the 2026.2 distribution module list before inventing alternate names.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/main/resources/META-INF/plugin.xml build.gradle.kts
+git commit -m "$(cat <<'EOF'
+build: declare JavaScript v2 content modules for 2026.2
+
+Add intellij.javascript.parser and intellij.javascript.backend so
+Struts taglib JS injectors can load under the fully v2 JavaScript plugin.
+EOF
+)"
+```
+
+---
+
+### Task 2: Verify build, plugin verifier, tests, and runIde smoke
+
+**Files:**
+- Modify only if escalation is required:
+  - `src/main/resources/META-INF/plugin.xml`
+  - `build.gradle.kts`
+
+**Interfaces:**
+- Consumes: Task 1 module declarations
+- Produces: evidence that the declared set is sufficient (or an escalated set that is)
+
+- [ ] **Step 1: Full build**
+
+Run:
+
+```bash
+./gradlew build --no-daemon
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 2: Plugin verifier against 2026.2**
+
+Run:
+
+```bash
+./gradlew runPluginVerifier --no-daemon
+```
+
+Expected: completes without Marketplace-blocking incompatibilities for the 262 target. Warnings about unrelated internal APIs may already exist; do not expand scope to clean those unless they block merge.
+
+- [ ] **Step 3: Enabled unit tests**
+
+Run:
+
+```bash
+./gradlew test -x rat --no-daemon
+```
+
+Expected: BUILD SUCCESSFUL for the currently enabled suite. Do not re-enable underscore-prefixed / historically disabled tests.
+
+- [ ] **Step 4: Manual `runIde` smoke for JSP JS injection**
+
+Run:
+
+```bash
+./gradlew runIde --no-daemon
+```
+
+In the launched IDE:
+
+1. Open or create a JSP that uses Struts UI / jQuery taglib attributes such as `onclick` / `onComplete` (any `on*` attribute covered by `TaglibJavaScriptInjector`).
+2. Confirm the attribute value gets JavaScript language injection (highlighting / language host present).
+3. Check Help → Show Log in Finder/Explorer (or the idea.log) for `NoClassDefFoundError` / `ClassNotFoundException` mentioning `com.intellij.lang.javascript`.
+
+Expected: injection works; no JS classloader errors.
+
+- [ ] **Step 5: Manual FreeMarker smoke (if FreeMarker plugin is available in the sandbox)**
+
+In the same `runIde` session, open a FreeMarker file using Struts taglib macros with `on*` / `doubleOn*` attributes (not ending in `Topics`). Confirm injection via `FreeMarkerJavaScriptInjector` and re-check the log.
+
+If FreeMarker is unavailable in the sandbox, note that in the PR and rely on the JSP smoke plus compile-time module resolution (injector still compiles against `JavaScriptSupportLoader`).
+
+- [ ] **Step 6: Escalate only if classloader errors remain**
+
+If Steps 4–5 (or earlier steps) show residual `com.intellij.lang.javascript.*` classloader failures, add `intellij.javascript.common` in both places:
+
+`plugin.xml` (after the two existing JS modules):
+
+```xml
+        <module name="intellij.javascript.common"/>
+```
+
+`build.gradle.kts` (after the two existing JS `bundledModule` lines):
+
+```kotlin
+        bundledModule("intellij.javascript.common")
+```
+
+Then re-run Steps 1–5. Only if `common` is still insufficient, add broader modules named in the failure (`psi.impl` / `analysis.impl` equivalents as documented by JetBrains for the missing class), never a speculative full JS module dump.
+
+If escalation changes files, commit before continuing:
+
+```bash
+git add src/main/resources/META-INF/plugin.xml build.gradle.kts
+git commit -m "$(cat <<'EOF'
+build: add intellij.javascript.common for residual JS classloader gaps
+
+Required after runIde/verifier showed missing com.intellij.lang.javascript classes
+beyond parser and backend modules.
+EOF
+)"
+```
+
+Adjust the commit message to name whatever module(s) were actually added.
+
+- [ ] **Step 7: No-op commit checkpoint if no escalation**
+
+If no escalation was needed, do not create an empty commit. Proceed to Task 3.
+
+---
+
+### Task 3: Changelog and handoff
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: final module set from Tasks 1–2
+- Produces: Unreleased changelog entry matching what was actually declared
+
+- [ ] **Step 1: Update `CHANGELOG.md`**
+
+Under `## [Unreleased]` → `### Changed`, add a bullet after the existing 2026.2 / dependency entries. If only the two planned modules were declared:
+
+```markdown
+- Dependencies - declare JavaScript v2 content modules `intellij.javascript.parser` and `intellij.javascript.backend` for IntelliJ Platform 2026.2 ([#103](https://github.com/apache/struts-intellij-plugin/issues/103))
+```
+
+If escalation added more modules, list every module that landed, for example:
+
+```markdown
+- Dependencies - declare JavaScript v2 content modules `intellij.javascript.parser`, `intellij.javascript.backend`, and `intellij.javascript.common` for IntelliJ Platform 2026.2 ([#103](https://github.com/apache/struts-intellij-plugin/issues/103))
+```
+
+Do not invent a Marketplace release section; keep under Unreleased.
+
+- [ ] **Step 2: Confirm descriptor/Gradle still match**
+
+Run:
+
+```bash
+rg -n 'intellij\.javascript\.(parser|backend|common)' \
+  src/main/resources/META-INF/plugin.xml build.gradle.kts CHANGELOG.md
+```
+
+Expected: every JS module named in `plugin.xml` also appears in `build.gradle.kts` and is mentioned in `CHANGELOG.md`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: record JavaScript v2 content modules in changelog
+
+Document the 2026.2 JavaScript modular dependency fix for #103.
+EOF
+)"
+```
+
+- [ ] **Step 4: Final status check**
+
+Run:
+
+```bash
+git status -sb
+git log --oneline main..HEAD
+```
+
+Expected: clean working tree; commits covering module wiring, optional escalation, and changelog. Ready for PR that closes #103.
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|---|---|
+| Declare `intellij.javascript.parser` + `intellij.javascript.backend` in `plugin.xml` | Task 1 |
+| Matching Gradle `bundledModule(...)` | Task 1 |
+| Keep existing `JavaScript` plugin dependency | Task 1 (explicit non-removal) |
+| Escalate to `common` / broader only with evidence | Task 2 Step 6 |
+| `./gradlew build` | Task 2 Step 1 |
+| `./gradlew runPluginVerifier` | Task 2 Step 2 |
+| `./gradlew test -x rat` | Task 2 Step 3 |
+| Manual `runIde` JSP + FreeMarker smoke | Task 2 Steps 4–5 |
+| No injector code changes | Global Constraints + File Structure |
+| No new automated JS injector tests | Global Constraints |
+| `CHANGELOG.md` updated | Task 3 |
+| No Marketplace release in this work | Global Constraints |

--- a/docs/superpowers/specs/2026-07-25-javascript-v2-modules-design.md
+++ b/docs/superpowers/specs/2026-07-25-javascript-v2-modules-design.md
@@ -1,0 +1,138 @@
+# JavaScript v2 Content Modules for IntelliJ Platform 2026.2
+
+**Issue:** [#103](https://github.com/apache/struts-intellij-plugin/issues/103)  
+**Date:** 2026-07-25  
+**Status:** Approved for implementation planning
+
+## Problem
+
+In IntelliJ Platform **2026.2**, the JavaScript plugin migrated to the **v2 plugin model**. Functionality is split into content modules; a plain dependency on the `JavaScript` plugin may no longer expose required classes at runtime.
+
+Typical linkage errors:
+
+```
+java.lang.NoClassDefFoundError: com/intellij/lang/javascript/JSElementTypes
+java.lang.ClassNotFoundException: com.intellij.lang.javascript.JSElementTypes
+```
+
+This plugin depends on JavaScript for language injection in Struts taglib attributes (JSP and FreeMarker). The platform target is already **2026.2** (`262.*`) via [#115](https://github.com/apache/struts-intellij-plugin/pull/115); what remains is declaring the v2 content modules that host the classes we use.
+
+## Goals
+
+1. Declare the JavaScript v2 content modules required for our injectors at runtime.
+2. Keep the existing `<plugin id="JavaScript"/>` / `bundledPlugin("JavaScript")` dependency — v2 `<module>` entries are additional.
+3. Match Gradle `bundledModule(...)` entries to `plugin.xml`.
+4. Expand the module set only when build, plugin verifier, or `runIde` shows a real classloader gap.
+5. Confirm JSP and FreeMarker Struts taglib JS injection works under 2026.2 without classloader errors.
+6. Document the change in `CHANGELOG.md`.
+
+## Non-Goals
+
+- Making the JavaScript dependency optional.
+- Changing injector logic or removing `com.intellij.lang.javascript.*` usage.
+- Marketplace release / prepare-publish as part of this work.
+- Adding new automated tests for JS injection (manual `runIde` smoke is the functional bar).
+- Re-enabling historically disabled tests.
+- Broader platform upgrades (already completed in #115).
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Approach | Minimal declarative fix — declare modules, keep injectors unchanged |
+| Initial modules | `intellij.javascript.parser` + `intellij.javascript.backend` |
+| Escalation | Add `intellij.javascript.common` only if residual classloader errors appear; then broader sets (`psi.impl`, `analysis.impl`) if still needed |
+| Keep `JavaScript` plugin dependency? | Yes — modules are additional, not a replacement |
+| Verification bar | `build` + `runPluginVerifier` + `test -x rat` + manual `runIde` smoke |
+| New automated JS injector tests? | No |
+
+## Scope of JavaScript API usage
+
+Only two production files import `com.intellij.lang.javascript.*`:
+
+| File | Classes used |
+|------|--------------|
+| `src/main/java/com/intellij/struts2/jsp/TaglibJavaScriptInjector.java` | `JavaScriptSupportLoader`, `JSInXmlLanguagesInjector` |
+| `src/main/java/com/intellij/struts2/freemarker/FreeMarkerJavaScriptInjector.java` | `JavaScriptSupportLoader` |
+
+No direct usage of `JSElementTypes`, `JSLanguage`, `JSReferenceExpression`, or JS lexers/parsers.
+
+## Architecture / components
+
+No production code changes. Wiring only, same pattern as existing `intellij.xml.structureView*` modules.
+
+| Unit | Role |
+|------|------|
+| `src/main/resources/META-INF/plugin.xml` | Keep `<plugin id="JavaScript"/>`; add `<module name="intellij.javascript.parser"/>` and `<module name="intellij.javascript.backend"/>` |
+| `build.gradle.kts` | Keep `bundledPlugin("JavaScript")`; add matching `bundledModule(...)` entries |
+| `TaglibJavaScriptInjector` | Unchanged |
+| `FreeMarkerJavaScriptInjector` | Unchanged (still loaded via optional `struts2-freemarker.xml`) |
+| `CHANGELOG.md` | Record JavaScript v2 content module dependencies |
+
+### Class → module mapping (initial)
+
+| Class | v2 module |
+|-------|-----------|
+| `JavaScriptSupportLoader` | `intellij.javascript.parser` |
+| `JSInXmlLanguagesInjector` | `intellij.javascript.backend` |
+
+### Descriptor sketch
+
+```xml
+<dependencies>
+    ...
+    <plugin id="JavaScript"/>
+    <module name="intellij.javascript.parser"/>
+    <module name="intellij.javascript.backend"/>
+    ...
+</dependencies>
+```
+
+### Gradle sketch
+
+```kotlin
+bundledPlugin("JavaScript")
+bundledModule("intellij.javascript.parser")
+bundledModule("intellij.javascript.backend")
+```
+
+## Verification and escalation
+
+Execute in this order:
+
+1. Apply the two module declarations in `plugin.xml` and `build.gradle.kts`.
+2. `./gradlew build`
+3. `./gradlew runPluginVerifier` against 2026.2
+4. `./gradlew test -x rat`
+5. Manual `./gradlew runIde` smoke: open a JSP (and FreeMarker if available) with Struts UI/jQuery `on*` attributes; confirm JS injection works and the IDE log has no `com.intellij.lang.javascript.*` classloader errors.
+6. Update `CHANGELOG.md`.
+
+### Escalation on classloader failure
+
+If `NoClassDefFoundError` / `ClassNotFoundException` for `com.intellij.lang.javascript.*` remains after the two modules:
+
+1. Add `intellij.javascript.common` in both descriptor and Gradle; re-verify.
+2. Only then consider broader modules (`psi.impl`, `analysis.impl`).
+3. Record whatever was actually required in `CHANGELOG.md`.
+
+## Delivery
+
+- Short-lived branch → PR closing #103.
+- Do **not** run prepare/publish release workflows as part of this work.
+- After merge, Marketplace impact depends on the next normal 262.x release.
+
+## Success criteria
+
+- [ ] `plugin.xml` declares `intellij.javascript.parser` and `intellij.javascript.backend` (plus any evidence-driven extras)
+- [ ] Gradle declares matching `bundledModule(...)` entries
+- [ ] `./gradlew build` and `./gradlew runPluginVerifier` pass against 2026.2
+- [ ] `./gradlew test -x rat` passes for the enabled suite
+- [ ] `./gradlew runIde` — JSP and FreeMarker Struts taglib JS injection works (no classloader errors)
+- [ ] `CHANGELOG.md` updated
+
+## References
+
+- [Plugin Dependencies — modular plugins](https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html)
+- [IntelliJ Platform Gradle Plugin — `bundledModule()`](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html)
+- JetBrains intellij-plugins commit WEB-77676: JavaScript plugin converted to fully-v2 modules
+- Prior platform bump: [#115](https://github.com/apache/struts-intellij-plugin/pull/115) / `docs/superpowers/specs/2026-07-24-intellij-2026-2-compatibility-design.md`

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -31,6 +31,8 @@
         <module name="intellij.javascript.parser"/>
         <module name="intellij.javascript.backend"/>
         <plugin id="com.intellij.css"/>
+        <module name="intellij.css"/>
+        <module name="intellij.css.backend"/>
         <plugin id="intellij.structureView.plugin"/>
         <plugin id="com.intellij.java-i18n"/>
     </dependencies>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -27,6 +27,8 @@
         <plugin id="com.intellij.javaee.web"/>
         <plugin id="com.intellij.jsp"/>
         <plugin id="JavaScript"/>
+        <module name="intellij.javascript.parser"/>
+        <module name="intellij.javascript.backend"/>
         <plugin id="com.intellij.css"/>
         <plugin id="intellij.structureView.plugin"/>
         <plugin id="com.intellij.java-i18n"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -26,6 +26,7 @@
         <plugin id="com.intellij.javaee"/>
         <plugin id="com.intellij.javaee.web"/>
         <plugin id="com.intellij.jsp"/>
+        <module name="intellij.javaee.jsp.shared"/>
         <plugin id="JavaScript"/>
         <module name="intellij.javascript.parser"/>
         <module name="intellij.javascript.backend"/>


### PR DESCRIPTION
## Summary
- Declare IntelliJ Platform 2026.2 v2 content modules required at runtime: `intellij.javascript.parser`, `intellij.javascript.backend`, plus evidence-driven escalations `intellij.javaee.jsp.shared`, `intellij.css`, and `intellij.css.backend`.
- Keep existing plugin dependencies (`JavaScript`, `com.intellij.jsp`, `com.intellij.css`); modules are additional classloader requirements under the v2 plugin model.
- Fixes `NoClassDefFoundError` for JS injector APIs and the confirmed `NewJspFileType` / CSS reference-provider classloader gaps when opening Struts projects on 2026.2.

Closes #103

## Test plan
- [x] `./gradlew compileJava` / `./gradlew build`
- [x] `./gradlew test -x rat`
- [x] `./gradlew verifyPlugin` against IU-262.9437.22 (1 pre-existing package-bundling warning only)
- [x] Manual `./gradlew runIde`: open a Struts project / JSP with `on*` attributes — confirm no `NewJspFileType` / JS / CSS classloader errors and taglib JS injection works
- [x] Optional: FreeMarker Struts taglib `on*` attribute injection smoke


Made with [Cursor](https://cursor.com)