### PR TITLE
Show Diagram: add arrowheads on action → result edges (#125)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Add IntelliJ **Show Diagram** support for Struts 2 configs via `com.intellij.diagram`, alongside the existing Diagram editor tab for comparison ([#117](https://github.com/apache/struts-intellij-plugin/issues/117))
 - Show Diagram Struts config nodes use compact icon+label chrome instead of empty UML class boxes ([#120](https://github.com/apache/struts-intellij-plugin/issues/120))
 - Show Diagram uses a left-to-right hierarchic layout by default for Struts config graphs ([#122](https://github.com/apache/struts-intellij-plugin/issues/122))
+- Show Diagram action → result edges use directed arrowheads while keeping package → action as dashed dependencies ([#125](https://github.com/apache/struts-intellij-plugin/issues/125))
 - Dependencies - hard-depend on `com.intellij.diagram` (Ultimate Diagrams)
 
 ## [261.19027.1] - 2026-07-13

--- a/docs/superpowers/plans/2026-07-26-show-diagram-result-edge-arrowheads.md
+++ b/docs/superpowers/plans/2026-07-26-show-diagram-result-edge-arrowheads.md
@@ -217,4 +217,3 @@ EOF
 - Swing tab removal or restyling
 - Robot / pixel assertions
 - #96–#100
-`)

--- a/docs/superpowers/plans/2026-07-26-show-diagram-result-edge-arrowheads.md
+++ b/docs/superpowers/plans/2026-07-26-show-diagram-result-edge-arrowheads.md
@@ -1,0 +1,220 @@
+# Show Diagram Result Edge Arrowheads Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make Show Diagram action → result (and other labeled) edges render with a clear `ANGLE` target arrow while keeping package → action as dashed `DEPENDENCY`.
+
+**Architecture:** Presentation-only fix in `StrutsDiagramApiEdge.relationshipFor`. Empty-label edges stay `DiagramRelationships.DEPENDENCY`. Labeled edges switch from the short no-arrow `DiagramRelationshipInfoAdapter` constructor to `DiagramRelationshipInfoAdapter.Builder` with solid line, `ANGLE` target arrow, and upper-center label. Extend existing mapping-test relationship verification; leave model, layout, Dom refresh, and Swing tab untouched.
+
+**Tech Stack:** IntelliJ IDEA Ultimate 2026.2 (262), `com.intellij.diagram` (`DiagramRelationshipInfoAdapter.Builder`, `DiagramRelationships`, `DiagramLineType`), JUnit 4 light tests (`BasicLightHighlightingTestCase`).
+
+**Spec:** `docs/superpowers/specs/2026-07-26-show-diagram-result-edge-arrowheads-design.md`
+
+## Global Constraints
+
+- Target platform remains IntelliJ IDEA **2026.2** / build **262** only (`pluginSinceBuild=262`, `pluginUntilBuild=262.*`).
+- Hard dependency on plugin id **`com.intellij.diagram`** already present — do not change dependency shape.
+- Touch **Show Diagram edge relationship presentation only** — do **not** modify or remove the Swing Diagram tab (`diagram.fileEditor` / `diagram.ui`).
+- Do **not** change `StrutsConfigDiagramModel` semantics, layouter extras, compact node chrome, Dom refresh, tooltips, or navigation.
+- Keep visual distinction: empty label → `DEPENDENCY` (dashed + `ANGLE`); non-empty label → solid + `ANGLE` + upper-center label.
+- Arrow shape for labeled edges is **`DiagramRelationshipInfo.ANGLE`** (same chevron as `DEPENDENCY`).
+- Do **not** implement per-kind edge presets, unify all edge styles, #96–#100, or Swing tab removal.
+- Tests gate: `./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"`.
+- If Builder / arrow accessor signatures drift, confirm against local IU SDK jar `plugins/uml/lib/uml-support.jar`.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java` | Modify | Assert labeled edges have solid line + `ANGLE` end/target arrow |
+| `src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramApiEdge.java` | Modify | Builder-based labeled relationship with `ANGLE` target arrow |
+| `CHANGELOG.md` | Modify | Unreleased note for Show Diagram arrowheads (#125) |
+
+No new production classes. No `plugin.xml` / Gradle dependency changes. No fixture XML changes (`struts-diagram.xml` already has package → action and a result edge).
+
+---
+
+### Task 1: Failing test for labeled edge arrowheads
+
+**Files:**
+- Modify: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java`
+- Test: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java`
+
+**Interfaces:**
+- Consumes:
+  - `DiagramEdge.getRelationship()`
+  - `DiagramRelationshipInfo.getLineType()`
+  - `DiagramRelationshipInfo.getEndArrow()` (Adapter stores Builder `setTargetArrow` here)
+  - `DiagramRelationshipInfo.ANGLE`
+  - `DiagramLineType.SOLID`
+  - Existing helpers `apiEdgeLabel`, `centerLabelText`, `verifyRelationshipMapping`
+- Produces: failing assertion that labeled relationships use solid line and `ANGLE` end arrow (currently null arrows from the short adapter ctor)
+
+- [ ] **Step 1: Add import for `DiagramLineType`**
+
+In `StrutsDiagramDataModelMappingTest.java`, add:
+
+```java
+import com.intellij.diagram.presentation.DiagramLineType;
+```
+
+Keep existing `DiagramRelationshipInfo` / `DiagramRelationships` imports.
+
+- [ ] **Step 2: Strengthen `verifyRelationshipMapping`**
+
+Replace the existing `verifyRelationshipMapping` method with:
+
+```java
+    private static void verifyRelationshipMapping(@NotNull DiagramEdge<StrutsDiagramItem> edge) {
+        String label = apiEdgeLabel(edge);
+        DiagramRelationshipInfo relationship = edge.getRelationship();
+        if (label.isEmpty()) {
+            assertSame("Unlabeled edges must use DEPENDENCY", DiagramRelationships.DEPENDENCY, relationship);
+        }
+        else {
+            assertNotSame("Labeled edges must not use DEPENDENCY", DiagramRelationships.DEPENDENCY, relationship);
+            assertEquals(label, centerLabelText(relationship.getUpperCenterLabel()));
+            assertEquals("Labeled edges must be solid", DiagramLineType.SOLID, relationship.getLineType());
+            assertSame("Labeled edges must have ANGLE target arrow",
+                    DiagramRelationshipInfo.ANGLE, relationship.getEndArrow());
+        }
+    }
+```
+
+`testRefreshMapsSnapshotNodesAndEdges` already calls `verifyRelationshipMapping` for every API edge on `struts-diagram.xml` (package → action unlabeled + action → result labeled as default result name). No new test method required unless that fixture somehow lacks a labeled edge — in that case fail fast with an explicit count assert; it should not.
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramDataModelMappingTest.testRefreshMapsSnapshotNodesAndEdges"
+```
+
+Expected: FAIL on the new `assertSame(... ANGLE ...)` (or solid/line assert) because labeled edges currently use the short adapter constructor with null arrows.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java
+git commit -m "$(cat <<'EOF'
+test(diagram): require ANGLE arrowheads on labeled Show Diagram edges (#125)
+
+EOF
+)"
+```
+
+---
+
+### Task 2: Builder-based labeled relationships + changelog
+
+**Files:**
+- Modify: `src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramApiEdge.java`
+- Modify: `CHANGELOG.md`
+- Test: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java`
+
+**Interfaces:**
+- Consumes:
+  - `StrutsDiagramEdge.getLabel()`
+  - `DiagramRelationships.DEPENDENCY`
+  - `DiagramRelationshipInfoAdapter.Builder`
+  - `DiagramRelationshipInfo.ANGLE`
+  - `DiagramLineType.SOLID`
+- Produces: labeled edges with solid line, `ANGLE` target arrow, upper-center label; unlabeled edges unchanged `DEPENDENCY`
+
+- [ ] **Step 1: Replace labeled-edge construction in `relationshipFor`**
+
+In `StrutsDiagramApiEdge.java`, replace `relationshipFor` with:
+
+```java
+    private static @NotNull DiagramRelationshipInfo relationshipFor(@NotNull StrutsDiagramEdge edge) {
+        String label = edge.getLabel();
+        if (label.isEmpty()) {
+            return DiagramRelationships.DEPENDENCY;
+        }
+        return new DiagramRelationshipInfoAdapter.Builder()
+                .setName(label)
+                .setLineType(DiagramLineType.SOLID)
+                .setTargetArrow(DiagramRelationshipInfo.ANGLE)
+                .setUpperCenterLabel(label)
+                .create();
+    }
+```
+
+Keep existing imports; `DiagramRelationshipInfo` is already imported (needed for `ANGLE`). No other methods in this class change.
+
+- [ ] **Step 2: Run mapping test to verify it passes**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramDataModelMappingTest.testRefreshMapsSnapshotNodesAndEdges"
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run full diagram test suite**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"
+```
+
+Expected: all diagram tests PASS (same count as before this change; currently 44 if unchanged since #124 — accept whatever the suite reports as long as zero failures).
+
+- [ ] **Step 4: Add changelog entry**
+
+Under `## [Unreleased]` → `### Changed` in `CHANGELOG.md`, add (near the other Show Diagram bullets):
+
+```markdown
+- Show Diagram action → result edges use directed arrowheads while keeping package → action as dashed dependencies ([#125](https://github.com/apache/struts-intellij-plugin/issues/125))
+```
+
+- [ ] **Step 5: Manual smoke (recommended before PR)**
+
+Run:
+
+```bash
+./gradlew runIde
+```
+
+Then: open a small Struts config → Show Diagram → confirm action → result edges show an arrow toward the result, labels like `success` remain readable, package → action stays dashed.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramApiEdge.java CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+fix(diagram): add ANGLE arrowheads on labeled Show Diagram edges (#125)
+
+EOF
+)"
+```
+
+---
+
+## Spec coverage checklist
+
+| Spec requirement | Task |
+|---|---|
+| Action → result clear directed arrow | Task 2 |
+| Labels remain readable (upper-center) | Task 2 (Builder `setUpperCenterLabel`) + Task 1 asserts |
+| Package → action stays `DEPENDENCY` / distinct | Task 1 + Task 2 empty-label branch |
+| Labeled chain/redirect same path | Task 2 (all non-empty labels) |
+| Automated relationship coverage | Task 1 |
+| Manual `runIde` check | Task 2 Step 5 |
+| Changelog | Task 2 Step 4 |
+| No model/layout/Swing/Dom changes | Global constraints + File Structure |
+
+## Out of scope (do not implement)
+
+- Per-kind RESULT vs CHAIN relationship presets
+- Unifying dashed package edges with solid result edges
+- Layout / compact nodes / Dom refresh changes
+- Swing tab removal or restyling
+- Robot / pixel assertions
+- #96–#100
+`)

--- a/docs/superpowers/specs/2026-07-26-show-diagram-result-edge-arrowheads-design.md
+++ b/docs/superpowers/specs/2026-07-26-show-diagram-result-edge-arrowheads-design.md
@@ -1,0 +1,143 @@
+# Show Diagram: Action → Result Edge Arrowheads
+
+**Date:** 2026-07-26  
+**Status:** Approved for implementation planning  
+**Related:** [#125](https://github.com/apache/struts-intellij-plugin/issues/125); follow-up to [#122](https://github.com/apache/struts-intellij-plugin/issues/122) / [#124](https://github.com/apache/struts-intellij-plugin/pull/124)
+
+## Problem
+
+After the Show Diagram LTR hierarchic layout fix (#122 / #124), package → action → result reads left-to-right correctly. Package → action edges use `DiagramRelationships.DEPENDENCY` (dashed line + `ANGLE` arrow). Action → result edges (and other labeled edges) are built with the short `DiagramRelationshipInfoAdapter(name, SOLID, label)` constructor, which passes null start/end arrows. Those edges render as plain solid curves without arrowheads, so flow direction is harder to read.
+
+## Goals
+
+1. Action → result edges show a clear directed arrow toward the result node.
+2. Edge labels (e.g. `success`, `delete`) remain readable on the upper-center label.
+3. Package → action stays visually distinct: dashed `DEPENDENCY` with `ANGLE` arrow, unlabeled.
+4. Labeled chain/redirect action → action edges use the same solid + `ANGLE` + label styling (same mapping path).
+5. Automated coverage for relationship arrow/label mapping, plus a short manual `runIde` check.
+6. Changelog documents the Show Diagram arrowhead fix.
+
+## Non-Goals
+
+- Redesigning edge taxonomy (separate RESULT vs CHAIN presets, colors, etc.).
+- Changing layout, compact node chrome, Dom refresh, navigation, or tooltips.
+- Unifying package → action with labeled edges (dashed vs solid distinction stays).
+- Swing Diagram tab pixel parity or Robot / UI e2e.
+- Model semantic changes in `StrutsConfigDiagramModel`.
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Visual distinction | Keep today’s dashed unlabeled package → action vs solid labeled result/chain edges |
+| Arrow shape for labeled edges | `DiagramRelationshipInfo.ANGLE` (same chevron as `DEPENDENCY`) |
+| Implementation API | `DiagramRelationshipInfoAdapter.Builder` for labeled edges |
+| Scope of arrow fix | All non-empty-label edges (action → result and labeled chain/redirect) |
+| Model / layout changes | None — relationship presentation only |
+| Verification | Unit asserts on mapped relationships + manual `runIde` |
+
+### Alternatives considered
+
+| Approach | Verdict |
+|---|---|
+| Builder: solid + `ANGLE` + upper-center label for labeled edges; keep `DEPENDENCY` for empty labels | **Chosen** — matches platform `DEPENDENCY` construction; smallest clear fix |
+| Full positional `DiagramRelationshipInfoAdapter` constructor with arrow shapes | Rejected — easy to mis-order args; less idiomatic on 262 |
+| Per-kind relationship presets (RESULT vs CHAIN vs PACKAGE) | Rejected for #125 — out of scope redesign |
+| Unify all edges to one style | Rejected — user chose to keep dashed vs solid distinction |
+
+## Architecture
+
+Root cause is presentation-only in the Show Diagram edge adapter. Snapshot edges already carry direction and labels; only the Diagrams `DiagramRelationshipInfo` lacks a target arrow for labeled edges.
+
+```
+StrutsConfigDiagramModel (unchanged)
+  └── StrutsDiagramEdge (source, target, label)
+        └── StrutsDiagramApiEdge.relationshipFor(edge)
+              ├── label empty  → DiagramRelationships.DEPENDENCY
+              │                    (DASHED + ANGLE target arrow, no label)
+              └── label present → DiagramRelationshipInfoAdapter.Builder
+                                   .setName(label)
+                                   .setLineType(SOLID)
+                                   .setTargetArrow(ANGLE)
+                                   .setUpperCenterLabel(label)
+                                   .create()
+```
+
+**Why the short constructor fails:**  
+`new DiagramRelationshipInfoAdapter(label, DiagramLineType.SOLID, label)` delegates to the full ctor with null start/end arrow shapes, so the graph paints a plain curve.
+
+**Unchanged:** `StrutsConfigDiagramModel`, `StrutsDiagramDataModel` structure, nodes, extras/layouter, Dom refresh, compact labels, Swing `fileEditor` / `ui`, `plugin.xml`.
+
+## Components
+
+| Unit | Role |
+|---|---|
+| `StrutsDiagramApiEdge` | Only production change: Builder-based labeled relationship with `ANGLE` target arrow; empty label still `DEPENDENCY` |
+| `StrutsDiagramDataModelMappingTest` | Extend relationship verification: labeled edges keep upper-center label, solid line, target/end arrow = `ANGLE`; unlabeled still `DEPENDENCY` |
+| Snapshot / provider / extras / Swing | Untouched |
+
+No new production classes. No `plugin.xml` changes for this issue.
+
+## Data flow
+
+1. User opens Show Diagram on a Struts config.
+2. Data model maps snapshot edges to `StrutsDiagramApiEdge`.
+3. Package → action (empty label) → dashed dependency arrow.
+4. Action → result / labeled chain-redirect (non-empty label) → solid curve with `ANGLE` at the target and the result name as upper-center label.
+5. Dom refresh rebuilds the same mapping; styling remains presentation-only.
+
+## Error handling & edge cases
+
+| Scenario | Behavior |
+|---|---|
+| Result name missing | Model already uses `Result.DEFAULT_NAME` as label → solid + arrow + that label |
+| Chain/redirect same-file action → action | Labeled edge → solid + `ANGLE` + label (same path) |
+| External/unresolved result node | Still a labeled action → result edge → solid + `ANGLE` + label |
+| Package → action | Unchanged `DEPENDENCY` |
+| Empty model / unavailable diagram | Unchanged |
+
+## Testing
+
+### Automated
+
+Extend `StrutsDiagramDataModelMappingTest.verifyRelationshipMapping` (or sibling asserts) after mapping a fixture that includes package → action and action → result (preferably also one labeled chain/redirect):
+
+1. Unlabeled edges: `getRelationship() == DiagramRelationships.DEPENDENCY`.
+2. Labeled edges: not `DEPENDENCY`; upper-center label equals snapshot label; line type solid; `getTargetArrow()` / `getEndArrow()` is `DiagramRelationshipInfo.ANGLE`.
+
+Gate: `./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"`
+
+Do not assert pixel geometry or rendered Swing strokes.
+
+### Manual (`./gradlew runIde` on IU)
+
+1. Show Diagram on a small Struts config with action → JSP results.
+2. Confirm action → result edges show an arrow toward the result node.
+3. Confirm labels such as `success` / `delete` remain readable.
+4. Confirm package → action remains dashed (visually distinct).
+
+### Out of scope
+
+- Pixel/layout assertions
+- Robot / UI e2e
+- Swing tab removal or restyling
+- Tests for #96–#100
+
+## Future work (out of scope)
+
+- Remove Swing Diagram tab once Show Diagram UX is solid
+- Optional richer edge taxonomy (distinct chain vs dispatcher styles)
+- [#96](https://github.com/apache/struts-intellij-plugin/issues/96) merged multi-file view
+- [#98](https://github.com/apache/struts-intellij-plugin/issues/98) selection sync
+- [#99](https://github.com/apache/struts-intellij-plugin/issues/99) Structure tool window
+- [#100](https://github.com/apache/struts-intellij-plugin/issues/100) zoom/pan beyond platform chrome
+
+## References
+
+- Issue [#125](https://github.com/apache/struts-intellij-plugin/issues/125)
+- `com.intellij.diagram.DiagramRelationshipInfoAdapter` / `Builder`
+- `com.intellij.diagram.DiagramRelationships.DEPENDENCY`
+- `com.intellij.diagram.DiagramRelationshipInfo.ANGLE`
+- `com.intellij.struts2.diagram.provider.StrutsDiagramApiEdge`
+- Prior LTR layout design: `docs/superpowers/specs/2026-07-26-show-diagram-ltr-layout-design.md`
+)

--- a/docs/superpowers/specs/2026-07-26-show-diagram-result-edge-arrowheads-design.md
+++ b/docs/superpowers/specs/2026-07-26-show-diagram-result-edge-arrowheads-design.md
@@ -140,4 +140,3 @@ Do not assert pixel geometry or rendered Swing strokes.
 - `com.intellij.diagram.DiagramRelationshipInfo.ANGLE`
 - `com.intellij.struts2.diagram.provider.StrutsDiagramApiEdge`
 - Prior LTR layout design: `docs/superpowers/specs/2026-07-26-show-diagram-ltr-layout-design.md`
-)

--- a/src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramApiEdge.java
+++ b/src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramApiEdge.java
@@ -38,6 +38,11 @@ public final class StrutsDiagramApiEdge extends DiagramEdgeBase<StrutsDiagramIte
         if (label.isEmpty()) {
             return DiagramRelationships.DEPENDENCY;
         }
-        return new DiagramRelationshipInfoAdapter(label, DiagramLineType.SOLID, label);
+        return new DiagramRelationshipInfoAdapter.Builder()
+                .setName(label)
+                .setLineType(DiagramLineType.SOLID)
+                .setTargetArrow(DiagramRelationshipInfo.ANGLE)
+                .setUpperCenterLabel(label)
+                .create();
     }
 }

--- a/src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java
+++ b/src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java
@@ -209,7 +209,7 @@ public class StrutsDiagramDataModelMappingTest extends BasicLightHighlightingTes
             assertEquals(label, centerLabelText(relationship.getUpperCenterLabel()));
             assertEquals("Labeled edges must be solid", DiagramLineType.SOLID, relationship.getLineType());
             assertSame("Labeled edges must have ANGLE target arrow",
-                    DiagramRelationshipInfo.ANGLE, relationship.getEndArrow());
+                    DiagramRelationshipInfo.ANGLE, relationship.getTargetArrow());
         }
     }
 }

--- a/src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java
+++ b/src/test/java/com/intellij/struts2/diagram/StrutsDiagramDataModelMappingTest.java
@@ -21,6 +21,7 @@ import com.intellij.diagram.DiagramNode;
 import com.intellij.diagram.DiagramProvider;
 import com.intellij.diagram.DiagramRelationshipInfo;
 import com.intellij.diagram.DiagramRelationships;
+import com.intellij.diagram.presentation.DiagramLineType;
 import com.intellij.openapi.application.ReadAction;
 import com.intellij.openapi.command.WriteCommandAction;
 import com.intellij.openapi.editor.Document;
@@ -199,12 +200,16 @@ public class StrutsDiagramDataModelMappingTest extends BasicLightHighlightingTes
 
     private static void verifyRelationshipMapping(@NotNull DiagramEdge<StrutsDiagramItem> edge) {
         String label = apiEdgeLabel(edge);
+        DiagramRelationshipInfo relationship = edge.getRelationship();
         if (label.isEmpty()) {
-            assertSame("Unlabeled edges must use DEPENDENCY", DiagramRelationships.DEPENDENCY, edge.getRelationship());
+            assertSame("Unlabeled edges must use DEPENDENCY", DiagramRelationships.DEPENDENCY, relationship);
         }
         else {
-            assertNotSame("Labeled edges must not use DEPENDENCY", DiagramRelationships.DEPENDENCY, edge.getRelationship());
-            assertEquals(label, centerLabelText(edge.getRelationship().getUpperCenterLabel()));
+            assertNotSame("Labeled edges must not use DEPENDENCY", DiagramRelationships.DEPENDENCY, relationship);
+            assertEquals(label, centerLabelText(relationship.getUpperCenterLabel()));
+            assertEquals("Labeled edges must be solid", DiagramLineType.SOLID, relationship.getLineType());
+            assertSame("Labeled edges must have ANGLE target arrow",
+                    DiagramRelationshipInfo.ANGLE, relationship.getEndArrow());
         }
     }
 }


### PR DESCRIPTION
## Summary
- Labeled Show Diagram edges (action → result and chain/redirect) use `DiagramRelationshipInfoAdapter.Builder` with solid line, `ANGLE` target arrow, and upper-center label
- Package → action stays dashed `DEPENDENCY`, so structural vs result flow remains visually distinct
- Mapping tests assert solid + `ANGLE` on labeled edges; changelog documents the fix for #125

Closes #125

## Test plan
- [x] `./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"` (44/44)
- [x] Manual `runIde`: Show Diagram on a small Struts config — action → result shows arrow toward result; labels like `success`/`delete` readable; package → action remains dashed


Made with [Cursor](https://cursor.com)