### PR TITLE
Clear Show Diagram Plugin Verifier deprecated APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Show Diagram uses a left-to-right hierarchic layout by default for Struts config graphs ([#122](https://github.com/apache/struts-intellij-plugin/issues/122))
 - Show Diagram action → result edges use directed arrowheads while keeping package → action as dashed dependencies ([#125](https://github.com/apache/struts-intellij-plugin/issues/125))
 - Show Diagram no longer auto-refreshes on `struts.xml` Dom edits; use the platform Refresh Data Model action after editing ([#126](https://github.com/apache/struts-intellij-plugin/issues/126))
+- Replace remaining deprecated `ReadAction.compute(ThrowableComputable)` Show Diagram call sites with `ReadAction.nonBlocking().executeSynchronously()`
+- Drop deprecated `DiagramExtras.createNodeComponent(..., Point, ...)` override; keep the `NodeRealizer` overload for compact Show Diagram nodes
 - Dependencies - hard-depend on `com.intellij.diagram` (Ultimate Diagrams)
 
 ### Fixed

--- a/docs/superpowers/plans/2026-07-27-deprecated-api-cleanup.md
+++ b/docs/superpowers/plans/2026-07-27-deprecated-api-cleanup.md
@@ -1,0 +1,336 @@
+# Deprecated API Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Clear Plugin Verifier deprecated-API hits for `DiagramExtras.createNodeComponent(Point)` and `ReadAction.compute` on the Show Diagram path, with no intentional behavior change.
+
+**Architecture:** Two independent surgical migrations. Keep the non-deprecated `NodeRealizer` `createNodeComponent` override that returns `createLabelNode`. Remove the redundant deprecated `Point` overload override. Replace leftover `ReadAction.compute` call sites with `ReadAction.nonBlocking(...).executeSynchronously()`, matching the pattern already used elsewhere in this plugin.
+
+**Tech Stack:** IntelliJ IDEA Ultimate 2026.2 (262), `com.intellij.diagram`, `ReadAction.nonBlocking`, JUnit 4 light tests (`BasicLightHighlightingTestCase`).
+
+**Spec:** `docs/superpowers/specs/2026-07-27-deprecated-api-cleanup-design.md`
+
+## Global Constraints
+
+- Target platform remains IntelliJ IDEA **2026.2** / build **262** only (`pluginSinceBuild=262`, `pluginUntilBuild=262.*`).
+- Touch only the listed Show Diagram / test / CHANGELOG files — do **not** modify Swing Diagram tab (`diagram.fileEditor` / `diagram.ui`).
+- Do **not** migrate to `com.intellij.diagram.v2`.
+- Do **not** use `ReadAction.computeBlocking()` as the primary replacement.
+- Keep `isReadAccessAllowed()` short-circuit in `StrutsDiagramVfsResolver`.
+- Keep compact label chrome via `NodeRealizer` overload → `createLabelNode`.
+- Tests gate: `./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramProviderTest"`.
+- Full diagram suite after both code tasks: `./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"`.
+- Verifier gate: `./gradlew runPluginVerifier` with zero hits for the two deprecated APIs in this report.
+- Manual `runIde` Show Diagram smoke required before calling the work done.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java` | Modify | Migrate 3× `ReadAction.compute`; add regression that Point overload is not declared on `StrutsDiagramExtras` |
+| `src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramVfsResolver.java` | Modify | Replace production `ReadAction.compute` with nonBlocking sync |
+| `src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramExtras.java` | Modify | Remove deprecated Point `createNodeComponent` override; drop unused `Point` import |
+| `CHANGELOG.md` | Modify | Unreleased note for both migrations |
+
+No new production classes. No `plugin.xml` / Gradle dependency changes.
+
+---
+
+### Task 1: Migrate `ReadAction.compute` (tests + VfsResolver)
+
+**Files:**
+- Modify: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java:107`
+- Modify: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java:136`
+- Modify: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java:160`
+- Modify: `src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramVfsResolver.java:56-58`
+- Test: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java`
+
+**Interfaces:**
+- Consumes: `ReadAction.nonBlocking(ThrowableComputable).executeSynchronously()`, `StrutsConfigDiagramModel.build(XmlFile)`, existing `isReadAccessAllowed()` short-circuit
+- Produces: no new public API; FQN resolve and provider tests keep the same synchronous contract
+
+- [ ] **Step 1: Update the three test `ReadAction.compute` call sites**
+
+In `StrutsDiagramProviderTest`, replace each:
+
+```java
+StrutsConfigDiagramModel model = ReadAction.compute(() -> StrutsConfigDiagramModel.build(xml));
+```
+
+with:
+
+```java
+StrutsConfigDiagramModel model = ReadAction.nonBlocking(
+        () -> StrutsConfigDiagramModel.build(xml)).executeSynchronously();
+```
+
+Exact sites:
+1. `testVfsResolverRoundTripsSnapshotNodeFqn` (~line 107)
+2. `testResolvePsiElementFromSnapshotNode` (~line 136)
+3. `testExtrasCreateCompactLabelNodeComponents` (~line 160)
+
+Do not change other test logic. Pattern reference: `StrutsConfigDiagramModelTest` / `Struts2ProblemFileHighlightFilter`.
+
+- [ ] **Step 2: Run provider tests (should still pass — tests no longer call deprecated compute)**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramProviderTest"
+```
+
+Expected: BUILD SUCCESSFUL; all tests in the class PASS. Production `StrutsDiagramVfsResolver` still uses `compute` until Step 3 — that is OK for this step; `testVfsResolverRoundTripsSnapshotNodeFqn` still exercises resolve.
+
+- [ ] **Step 3: Migrate production `StrutsDiagramVfsResolver`**
+
+Replace the model-build branch in `resolveElementByFQN` so it becomes:
+
+```java
+if (nodeSeparator >= 0) {
+    String nodeId = fqn.substring(nodeSeparator + 1);
+    StrutsConfigDiagramModel model = ApplicationManager.getApplication().isReadAccessAllowed()
+            ? StrutsConfigDiagramModel.build(xmlFile)
+            : ReadAction.nonBlocking(() -> StrutsConfigDiagramModel.build(xmlFile))
+                    .executeSynchronously();
+    if (model != null) {
+        StrutsDiagramNode node = model.getNodes().stream()
+                .filter(candidate -> candidate.getId().equals(nodeId))
+                .findFirst()
+                .orElse(null);
+        if (node != null) {
+            return StrutsDiagramItem.forNode(xmlFile, node);
+        }
+    }
+}
+```
+
+Keep the `isReadAccessAllowed()` short-circuit. Keep the rest of the class unchanged.
+
+- [ ] **Step 4: Re-run provider tests**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramProviderTest"
+```
+
+Expected: BUILD SUCCESSFUL; `testVfsResolverRoundTripsSnapshotNodeFqn` PASS.
+
+- [ ] **Step 5: Confirm no remaining `ReadAction.compute` in these files**
+
+Run:
+
+```bash
+rg "ReadAction\\.compute" src/main/java/com/intellij/struts2/diagram src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java
+```
+
+Expected: no matches.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add \
+  src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java \
+  src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramVfsResolver.java
+git commit -m "$(cat <<'EOF'
+fix(diagram): migrate leftover ReadAction.compute call sites
+
+Use ReadAction.nonBlocking().executeSynchronously() in VfsResolver and
+StrutsDiagramProviderTest to match the 2026.2 cancellable read-action API.
+EOF
+)"
+```
+
+---
+
+### Task 2: Drop deprecated Point `createNodeComponent` override
+
+**Files:**
+- Modify: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java`
+- Modify: `src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramExtras.java:46-47` (Point import) and `:98-104` (Point overload)
+- Test: `src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java`
+
+**Interfaces:**
+- Consumes: existing `createNodeComponent(DiagramNode, DiagramBuilder, NodeRealizer, JPanel)` → `createLabelNode`
+- Produces: `StrutsDiagramExtras` no longer declares the deprecated Point overload; platform default remains unused for Struts compact labels
+
+- [ ] **Step 1: Write failing regression that Point overload is not declared**
+
+Add imports if missing:
+
+```java
+import java.awt.Point;
+import java.lang.reflect.Method;
+```
+
+Add test method to `StrutsDiagramProviderTest`:
+
+```java
+public void testExtrasDoNotOverrideDeprecatedPointCreateNodeComponent() {
+    Method pointOverload = null;
+    try {
+        pointOverload = StrutsDiagramExtras.class.getDeclaredMethod(
+                "createNodeComponent",
+                DiagramNode.class,
+                DiagramBuilder.class,
+                Point.class,
+                JPanel.class);
+    } catch (NoSuchMethodException ignored) {
+        // expected once the deprecated override is removed
+    }
+    assertNull(
+            "Must not override deprecated DiagramExtras.createNodeComponent(..., Point, ...)",
+            pointOverload);
+}
+```
+
+Keep `testExtrasCreateCompactLabelNodeComponents` unchanged — it already calls the `NodeRealizer` overload.
+
+- [ ] **Step 2: Run the new test to verify it fails**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramProviderTest.testExtrasDoNotOverrideDeprecatedPointCreateNodeComponent"
+```
+
+Expected: FAIL — assertion error because `pointOverload` is non-null (method still declared on `StrutsDiagramExtras`).
+
+- [ ] **Step 3: Remove the Point overload from `StrutsDiagramExtras`**
+
+Delete this entire method:
+
+```java
+@Override
+public @NotNull JComponent createNodeComponent(@NotNull DiagramNode<StrutsDiagramItem> node,
+                                               @NotNull DiagramBuilder builder,
+                                               @NotNull Point basePoint,
+                                               @NotNull JPanel wrapper) {
+    return createLabelNode(node, builder, wrapper);
+}
+```
+
+Remove the unused import:
+
+```java
+import java.awt.Point;
+```
+
+Keep the `NodeRealizer` overload exactly as-is:
+
+```java
+@Override
+public @NotNull JComponent createNodeComponent(@NotNull DiagramNode<StrutsDiagramItem> node,
+                                               @NotNull DiagramBuilder builder,
+                                               @NotNull NodeRealizer nodeRealizer,
+                                               @NotNull JPanel wrapper) {
+    return createLabelNode(node, builder, wrapper);
+}
+```
+
+- [ ] **Step 4: Run provider tests**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.StrutsDiagramProviderTest"
+```
+
+Expected: BUILD SUCCESSFUL; `testExtrasDoNotOverrideDeprecatedPointCreateNodeComponent` PASS; `testExtrasCreateCompactLabelNodeComponents` PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add \
+  src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java \
+  src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramExtras.java
+git commit -m "$(cat <<'EOF'
+fix(diagram): drop deprecated Point createNodeComponent override
+
+Keep the NodeRealizer overload for compact label nodes; remove the
+deprecated Point overload flagged by Plugin Verifier on 2026.2.
+EOF
+)"
+```
+
+---
+
+### Task 3: CHANGELOG + verifier + manual smoke
+
+**Files:**
+- Modify: `CHANGELOG.md` (Unreleased / Changed)
+- Test: verifier + manual `runIde` (no new automated test file)
+
+**Interfaces:**
+- Consumes: Tasks 1–2 completed on the working branch
+- Produces: documented Unreleased notes; green verifier for the two targeted APIs; manual smoke confirmation
+
+- [ ] **Step 1: Update CHANGELOG Unreleased**
+
+Under `## [Unreleased]` → `### Changed`, add:
+
+```markdown
+- Replace remaining deprecated `ReadAction.compute(ThrowableComputable)` Show Diagram call sites with `ReadAction.nonBlocking().executeSynchronously()`
+- Drop deprecated `DiagramExtras.createNodeComponent(..., Point, ...)` override; keep the `NodeRealizer` overload for compact Show Diagram nodes
+```
+
+Place near the other Show Diagram Unreleased bullets. Do not invent issue numbers unless a tracking issue already exists.
+
+- [ ] **Step 2: Run full diagram unit suite**
+
+Run:
+
+```bash
+./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"
+```
+
+Expected: BUILD SUCCESSFUL.
+
+- [ ] **Step 3: Run Plugin Verifier**
+
+Run:
+
+```bash
+./gradlew runPluginVerifier
+```
+
+Expected: report no longer lists:
+- `DiagramExtras.createNodeComponent(...)`
+- `ReadAction.compute(ThrowableComputable)`
+
+If the report path differs, search the verifier output / `build/reports/pluginVerifier` for those two strings — both must be absent.
+
+- [ ] **Step 4: Manual `runIde` smoke**
+
+Run:
+
+```bash
+./gradlew runIde
+```
+
+Checklist:
+1. Open a Struts 2 `struts.xml` (or test fixture config) that has package/action/result.
+2. Invoke **Show Diagram**.
+3. Confirm nodes are compact icon+label (not empty UML class boxes).
+4. Double-click a node or use Jump to Source — navigation still works.
+
+- [ ] **Step 5: Commit CHANGELOG**
+
+```bash
+git add CHANGELOG.md
+git commit -m "$(cat <<'EOF'
+docs: changelog for Show Diagram deprecated API cleanup
+
+EOF
+)"
+```
+
+---
+
+## Self-Review Checklist (plan author)
+
+1. **Spec coverage:** Point override removal → Task 2; ReadAction production + tests → Task 1; CHANGELOG → Task 3; unit tests + verifier + manual smoke → Task 3 (plus per-task test steps). Non-goals (v2, Swing tab, computeBlocking) not scheduled.
+2. **Placeholders:** None — exact snippets, commands, and expected results included.
+3. **Type consistency:** `NodeRealizer` overload kept; Point overload removed; `ReadAction.nonBlocking(...).executeSynchronously()` matches existing call sites.

--- a/docs/superpowers/specs/2026-07-27-deprecated-api-cleanup-design.md
+++ b/docs/superpowers/specs/2026-07-27-deprecated-api-cleanup-design.md
@@ -1,0 +1,110 @@
+# Deprecated API Cleanup (Show Diagram / ReadAction)
+
+**Date:** 2026-07-27  
+**Status:** Approved for implementation planning  
+**Related:** Plugin Verifier report on `262.19039-nightly.2`; prior migrations in CHANGELOG (`ReadAction.nonBlocking().executeSynchronously()`); compact nodes [#120](https://github.com/apache/struts-intellij-plugin/issues/120) / `2026-07-25-show-diagram-compact-nodes-design.md`
+
+## Problem
+
+Plugin Verifier reports that Apache Struts `262.19039-nightly.2` uses deprecated APIs that may be removed later:
+
+| Deprecated API | Count | Location |
+|---|---|---|
+| `DiagramExtras.createNodeComponent(...)` | 1 | `StrutsDiagramExtras` overrides the `Point`-based overload |
+| `ReadAction.compute(ThrowableComputable)` | 1 | `StrutsDiagramVfsResolver` (diagram tests also still call `compute`) |
+
+On IntelliJ Platform 2026.2 (`uml-support.jar`):
+
+- `DiagramExtras.createNodeComponent(DiagramNode, DiagramBuilder, Point, JPanel)` is `@Deprecated`.
+- The replacement overload takes `NodeRealizer` instead of `Point` and is not deprecated.
+- Non-cancellable `ReadAction.compute` / `run` are deprecated in favor of cancellable APIs (`ReadAction.nonBlocking().submit()` / `.executeSynchronously()` in Java).
+
+`StrutsDiagramExtras` currently overrides **both** overloads and routes them to the same `createLabelNode(...)` helper, so the Point override is redundant. Most of the plugin already migrated off `ReadAction.compute`; these Show Diagram call sites were left behind.
+
+## Goals
+
+1. Clear both Plugin Verifier deprecated-API hits for this report.
+2. Keep Show Diagram compact icon+label chrome via the non-deprecated `NodeRealizer` `createNodeComponent` overload.
+3. Migrate production **and** diagram test `ReadAction.compute` sites for consistency with the existing codebase pattern.
+4. No intentional behavior change to layout, navigation, or snapshot model.
+5. Verify with diagram unit tests, `runPluginVerifier`, and a short manual `runIde` Show Diagram smoke check.
+6. Document in CHANGELOG under Unreleased.
+
+## Non-Goals
+
+- Migrating other deprecated APIs not listed in this verifier report.
+- Moving Show Diagram to `com.intellij.diagram.v2`.
+- Changing the leftover Swing Diagram tab (`diagram.fileEditor` / `diagram.ui`).
+- Changing layouter, edge rendering, Dom refresh, or node chrome beyond removing the deprecated override.
+- Using `ReadAction.computeBlocking()` as the primary replacement (JetBrains documents it as last resort).
+
+## Decisions
+
+| Question | Decision |
+|---|---|
+| Scope | Production + diagram test call sites (verifier production hit + test consistency) |
+| Diagram fix | Remove Point overload override only; keep `NodeRealizer` → `createLabelNode` |
+| ReadAction fix | `ReadAction.nonBlocking(...).executeSynchronously()`, matching prior CHANGELOG migration |
+| VfsResolver short-circuit | Keep `isReadAccessAllowed()` → direct `build`; else nonBlocking sync |
+| Verification | Unit tests + `runPluginVerifier` + manual `runIde` Show Diagram smoke |
+
+### Alternatives considered
+
+| Approach | Verdict |
+|---|---|
+| Surgical migration (drop Point override; nonBlocking sync for ReadAction) | **Chosen** — smallest diff; matches existing patterns; clears both warnings |
+| `ReadAction.computeBlocking()` for sync FQN resolve | Rejected — documented last resort; worse than pattern already used elsewhere |
+| Broader deprecation hunt / diagram v2 | Rejected — out of scope for these two verifier hits |
+
+## Architecture
+
+No new components. Two independent, localized API migrations on the existing Show Diagram path.
+
+```
+StrutsDiagramExtras
+  createNodeComponent(..., NodeRealizer, ...) → createLabelNode(...)   // keep
+  createNodeComponent(..., Point, ...)                                 // remove override
+
+StrutsDiagramVfsResolver.resolveElementByFQN
+  isReadAccessAllowed? build(xml) : ReadAction.nonBlocking(build).executeSynchronously()
+
+StrutsDiagramProviderTest (3 sites)
+  ReadAction.nonBlocking(build).executeSynchronously()
+```
+
+**Risk:** If any host still invoked the Point overload and relied on our override, removing it would fall through to the platform default UML `DiagramNodeContainer`. On 262 the platform routes through `NodeRealizer`; the compact-node smoke test already exercises that path.
+
+**Unchanged:** `createLabelNode` chrome, custom LTR layouter, EditNodeHandler / uiDataSnapshot, data model, Swing tab, `plugin.xml`.
+
+## Components
+
+| Unit | Role |
+|---|---|
+| `StrutsDiagramExtras` | Delete Point `createNodeComponent` override; drop unused `java.awt.Point` import if present. Keep NodeRealizer overload and all other extras behavior. |
+| `StrutsDiagramVfsResolver` | Replace the single `ReadAction.compute` with `ReadAction.nonBlocking(...).executeSynchronously()`. Preserve read-access short-circuit. |
+| `StrutsDiagramProviderTest` | Migrate three `ReadAction.compute` model-build sites the same way. Compact-node smoke already calls the NodeRealizer overload — no Point test path to update. |
+| `CHANGELOG.md` | Unreleased note covering both migrations. |
+
+## Error handling
+
+No new failure modes. `executeSynchronously()` preserves the previous synchronous contract for FQN resolution and test setup. Exceptions from `StrutsConfigDiagramModel.build` continue to propagate as before.
+
+## Testing
+
+**Automated**
+
+- Run diagram unit tests touching the changed files (at least `StrutsDiagramProviderTest`).
+- `./gradlew runPluginVerifier` — expect zero hits for `DiagramExtras.createNodeComponent` and `ReadAction.compute(ThrowableComputable)`.
+
+**Manual (`runIde`)**
+
+1. Open a Struts 2 config → Show Diagram.
+2. Confirm compact icon+label nodes (not empty UML boxes).
+3. Spot-check navigation (double-click / Jump to Source).
+
+## Done criteria
+
+- Both verifier deprecated-API warnings from this report are gone.
+- Diagram unit tests green.
+- Manual Show Diagram smoke OK.
+- CHANGELOG Unreleased updated.

--- a/src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramExtras.java
+++ b/src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramExtras.java
@@ -43,7 +43,6 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.JComponent;
 import javax.swing.JPanel;
-import java.awt.Point;
 import java.util.List;
 
 /**
@@ -91,14 +90,6 @@ public final class StrutsDiagramExtras extends CommonDiagramExtras<StrutsDiagram
     public @NotNull JComponent createNodeComponent(@NotNull DiagramNode<StrutsDiagramItem> node,
                                                    @NotNull DiagramBuilder builder,
                                                    @NotNull NodeRealizer nodeRealizer,
-                                                   @NotNull JPanel wrapper) {
-        return createLabelNode(node, builder, wrapper);
-    }
-
-    @Override
-    public @NotNull JComponent createNodeComponent(@NotNull DiagramNode<StrutsDiagramItem> node,
-                                                   @NotNull DiagramBuilder builder,
-                                                   @NotNull Point basePoint,
                                                    @NotNull JPanel wrapper) {
         return createLabelNode(node, builder, wrapper);
     }

--- a/src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramVfsResolver.java
+++ b/src/main/java/com/intellij/struts2/diagram/provider/StrutsDiagramVfsResolver.java
@@ -55,7 +55,8 @@ public final class StrutsDiagramVfsResolver implements DiagramVfsResolver<Struts
             String nodeId = fqn.substring(nodeSeparator + 1);
             StrutsConfigDiagramModel model = ApplicationManager.getApplication().isReadAccessAllowed()
                     ? StrutsConfigDiagramModel.build(xmlFile)
-                    : ReadAction.compute(() -> StrutsConfigDiagramModel.build(xmlFile));
+                    : ReadAction.nonBlocking(() -> StrutsConfigDiagramModel.build(xmlFile))
+                            .executeSynchronously();
             if (model != null) {
                 StrutsDiagramNode node = model.getNodes().stream()
                         .filter(candidate -> candidate.getId().equals(nodeId))

--- a/src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java
+++ b/src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java
@@ -104,7 +104,8 @@ public class StrutsDiagramProviderTest extends BasicLightHighlightingTestCase {
         XmlFile xml = (XmlFile) PsiManager.getInstance(getProject()).findFile(file);
         assertNotNull(xml);
 
-        StrutsConfigDiagramModel model = ReadAction.compute(() -> StrutsConfigDiagramModel.build(xml));
+        StrutsConfigDiagramModel model = ReadAction.nonBlocking(
+                () -> StrutsConfigDiagramModel.build(xml)).executeSynchronously();
         assertNotNull(model);
         StrutsDiagramNode node = model.getNodes().get(0);
         DiagramVfsResolver<StrutsDiagramItem> resolver = getProvider().getVfsResolver();
@@ -133,7 +134,8 @@ public class StrutsDiagramProviderTest extends BasicLightHighlightingTestCase {
         XmlFile xml = (XmlFile) PsiManager.getInstance(getProject()).findFile(file);
         assertNotNull(xml);
 
-        StrutsConfigDiagramModel model = ReadAction.compute(() -> StrutsConfigDiagramModel.build(xml));
+        StrutsConfigDiagramModel model = ReadAction.nonBlocking(
+                () -> StrutsConfigDiagramModel.build(xml)).executeSynchronously();
         assertNotNull(model);
         StrutsDiagramNode snapshotNode = model.getNodes().stream()
                 .filter(n -> n.getKind() == StrutsDiagramNode.Kind.ACTION)
@@ -157,7 +159,8 @@ public class StrutsDiagramProviderTest extends BasicLightHighlightingTestCase {
         XmlFile xml = (XmlFile) PsiManager.getInstance(getProject()).findFile(file);
         assertNotNull(xml);
 
-        StrutsConfigDiagramModel model = ReadAction.compute(() -> StrutsConfigDiagramModel.build(xml));
+        StrutsConfigDiagramModel model = ReadAction.nonBlocking(
+                () -> StrutsConfigDiagramModel.build(xml)).executeSynchronously();
         assertNotNull(model);
         StrutsDiagramNode snapshotNode = model.getNodes().stream()
                 .filter(n -> n.getKind() == StrutsDiagramNode.Kind.ACTION)

--- a/src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java
+++ b/src/test/java/com/intellij/struts2/diagram/StrutsDiagramProviderTest.java
@@ -18,6 +18,7 @@ package com.intellij.struts2.diagram;
 
 import com.intellij.diagram.DiagramBuilder;
 import com.intellij.diagram.DiagramDataModel;
+import com.intellij.diagram.DiagramNode;
 import com.intellij.diagram.DiagramProvider;
 import com.intellij.diagram.DiagramVfsResolver;
 import com.intellij.diagram.components.DiagramNodeContainer;
@@ -54,6 +55,8 @@ import org.jetbrains.annotations.Nullable;
 
 import javax.swing.JComponent;
 import javax.swing.JPanel;
+import java.awt.Point;
+import java.lang.reflect.Method;
 import java.lang.reflect.Proxy;
 
 public class StrutsDiagramProviderTest extends BasicLightHighlightingTestCase {
@@ -150,6 +153,23 @@ public class StrutsDiagramProviderTest extends BasicLightHighlightingTestCase {
 
         StrutsDiagramApiNode apiNode = new StrutsDiagramApiNode(getProvider(), item);
         assertTrue(apiNode.canNavigate());
+    }
+
+    public void testExtrasDoNotOverrideDeprecatedPointCreateNodeComponent() {
+        Method pointOverload = null;
+        try {
+            pointOverload = StrutsDiagramExtras.class.getDeclaredMethod(
+                    "createNodeComponent",
+                    DiagramNode.class,
+                    DiagramBuilder.class,
+                    Point.class,
+                    JPanel.class);
+        } catch (NoSuchMethodException ignored) {
+            // expected once the deprecated override is removed
+        }
+        assertNull(
+                "Must not override deprecated DiagramExtras.createNodeComponent(..., Point, ...)",
+                pointOverload);
     }
 
     public void testExtrasCreateCompactLabelNodeComponents() {


### PR DESCRIPTION
## Summary
- Replace leftover `ReadAction.compute` call sites in Show Diagram (`StrutsDiagramVfsResolver` + provider tests) with `ReadAction.nonBlocking().executeSynchronously()`
- Drop the deprecated `DiagramExtras.createNodeComponent(..., Point, ...)` override; keep the `NodeRealizer` overload for compact label nodes
- Document the cleanup in CHANGELOG and add design/plan under `docs/superpowers/`

## Test plan
- [x] `./gradlew test -x rat --tests "com.intellij.struts2.diagram.*"` (49 tests green)
- [x] `./gradlew verifyPlugin` — zero hits for `DiagramExtras.createNodeComponent` and `ReadAction.compute(ThrowableComputable)`
- [x] Manual `runIde` smoke: Show Diagram compact icon+label nodes + Jump to Source / double-click navigation


Made with [Cursor](https://cursor.com)